### PR TITLE
Supporting hashes in the fake login url

### DIFF
--- a/cypress/integration/fake-login.spec.ts
+++ b/cypress/integration/fake-login.spec.ts
@@ -2,24 +2,37 @@
 /// <reference types="../../" />
 
 describe("Keycloak Fake Login", () => {
-  beforeEach(() => {
-    cy.kcFakeLogin("user");
-  });
+  describe("without a given path", () => {
+    beforeEach(() => {
+      cy.kcFakeLogin("user");
+    });
 
-  it("should show user as authenticated", () => {
-    cy.get("#output").should("contain.text", "Init Success (Authenticated)");
-  });
+    it("should show user as authenticated", () => {
+      cy.get("#output").should("contain.text", "Init Success (Authenticated)");
+    });
 
-  it("should get user data equal to fixture data", () => {
-    cy.get("#output").should("contain.text", "Init Success (Authenticated)");
+    it("should get user data equal to fixture data", () => {
+      cy.get("#output").should("contain.text", "Init Success (Authenticated)");
 
-    cy.findByText("Get Profile").click();
+      cy.findByText("Get Profile").click();
 
-    cy.fixture("users/user.json").then((userData: UserData) => {
-      cy.get("#output").should(el => {
-        const value = JSON.parse(el.text());
-        expect(value).to.deep.equal(userData.fakeLogin?.account);
+      cy.fixture("users/user.json").then((userData: UserData) => {
+        cy.get("#output").should(el => {
+          const value = JSON.parse(el.text());
+          expect(value).to.deep.equal(userData.fakeLogin?.account);
+        });
       });
     });
+
+  });
+  describe("with a path", () => {
+    beforeEach(() => {
+      cy.kcFakeLogin("user", "#/foobar");
+    });
+
+    it("should show user as authenticated again", () => {
+      cy.get("#output").should("contain.text", "Init Success (Authenticated)");
+    });
+
   });
 });

--- a/src/kc-fake-login.ts
+++ b/src/kc-fake-login.ts
@@ -57,9 +57,12 @@ Cypress.Commands.add("kcFakeLogin", (user: string, visitUrl = "") => {
 
     cy.route(`${authBaseUrl}/realms/${realm}/account`, account);
 
+    // in case visitUrl is an url with a hash, a second hash should not be added to the url
+    const joiningCharacter = visitUrl.indexOf("#") === -1 ? "#" : "&";
+
     const url = `${
       Cypress.config().baseUrl
-    }/${visitUrl}#state=${state}&session_state=${createUUID()}&code=${createUUID()}`;
+    }/${visitUrl}${joiningCharacter}state=${state}&session_state=${createUUID()}&code=${createUUID()}`;
 
     cy.visit(url);
   });


### PR DESCRIPTION
Hi! 

Thanks for an amazing library! I set it up with my cypress tests and it seems to work fairly well. However I ran into a problem when I wanted to visit an URL mit a Hash in it.

``
cy.kcFakeLogin2('user', "#/foobar");
``
This led to a situation where there were two hashes added to the url. This PR fixes this problem.